### PR TITLE
feat: 新增文章瀏覽數與網站累積/今日瀏覽量統計

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,9 @@ footer{border-top:1px solid var(--border);padding:28px 24px;text-align:center;fo
   .hero-brand{font-size:clamp(2.8rem,14vw,5rem);}
 }
 
+/* POST VIEW BADGE */
+.pc-view-cnt{color:var(--dim);}
+
 ::selection{background:rgba(0,245,255,.2);color:#fff;}
 ::-webkit-scrollbar{width:4px;}
 ::-webkit-scrollbar-track{background:var(--bg2);}
@@ -343,6 +346,8 @@ footer{border-top:1px solid var(--border);padding:28px 24px;text-align:center;fo
         <div><div class="stat-n" id="s1n">50+</div><div class="stat-l" id="s1l">篇文章</div></div>
         <div><div class="stat-n" id="s2n">5</div><div class="stat-l" id="s2l">核心主題</div></div>
         <div><div class="stat-n" id="s3n">∞</div><div class="stat-l" id="s3l">持續更新</div></div>
+        <div><div class="stat-n" style="color:var(--pink);text-shadow:0 0 10px var(--pink);" id="stat-total">—</div><div class="stat-l">累積瀏覽</div></div>
+        <div><div class="stat-n" style="color:var(--green);text-shadow:0 0 10px var(--green);" id="stat-today">—</div><div class="stat-l">今日瀏覽</div></div>
       </div>
     </div>
   </div>
@@ -370,6 +375,7 @@ footer{border-top:1px solid var(--border);padding:28px 24px;text-align:center;fo
   <div class="art-meta">
     <span>📅 <span id="a-date"></span></span>
     <span>⏱ <span id="a-rt"></span> 分鐘閱讀</span>
+    <span>👁 <span id="a-views">0</span> 次瀏覽</span>
     <span id="a-cat-tag"></span>
   </div>
   <img class="art-cover" id="a-cover" style="display:none;" alt="封面圖">
@@ -426,24 +432,31 @@ let D={posts:[],hp:DEFAULTS.hp,about:DEFAULTS.about,footer:DEFAULTS.footer};
 
 // ── DB INIT ──
 async function initDB(){
+  const today=new Date().toISOString().slice(0,10);
   try{
-    const [pr,sr]=await Promise.all([
+    const [pr,sr,svr]=await Promise.all([
       sb.from('posts').select('*').eq('status','published').order('date',{ascending:false}),
-      sb.from('settings').select('*')
+      sb.from('settings').select('*'),
+      sb.from('site_stats').select('*').in('id',['total',today])
     ]);
     if(pr.error)throw pr.error;
     const sm={};
     (sr.data||[]).forEach(s=>{sm[s.key]=s.value;});
+    const sv={total:0,today:0};
+    (svr.data||[]).forEach(s=>{if(s.id==='total')sv.total=s.count;else sv.today=s.count;});
     D={
       posts:pr.data||[],
       hp:sm.hp||DEFAULTS.hp,
       about:sm.about||DEFAULTS.about,
-      footer:(sm.footer&&sm.footer.text)||DEFAULTS.footer
+      footer:(sm.footer&&sm.footer.text)||DEFAULTS.footer,
+      siteViews:sv
     };
   }catch(err){
     console.error('Supabase error:',err);
     D=JSON.parse(JSON.stringify(DEFAULTS));
+    D.siteViews={total:0,today:0};
   }
+  sb.rpc('increment_site_views').catch(()=>{});
   renderHome();
 }
 
@@ -462,6 +475,9 @@ function renderHome(){
   setText('s3n',a.s3n);setText('s3l',a.s3l);
   setText('nl-t',h.nlt);setText('nl-d',h.nld);
   setText('footer-text',D.footer||'');
+  const sv=D.siteViews||{total:0,today:0};
+  setText('stat-total',fmtViews(sv.total));
+  setText('stat-today',fmtViews(sv.today));
   updateTopicCounts();
   renderGrid('grid-main',publishedPosts());
 }
@@ -497,7 +513,7 @@ function cardHTML(p){
     +'<div class="pc-img">'+img+'<span class="pc-badge" style="border-color:'+c+';color:'+c+';">'+esc(p.category)+'</span></div>'
     +'<div class="pc-body"><div class="pc-title">'+esc(p.title)+'</div>'
     +'<div class="pc-exc">'+esc(p.excerpt||'')+'</div>'
-    +'<div class="pc-foot"><span>📅 '+esc(p.date)+'</span><span class="pc-rt">⏱ '+rt+' 分鐘</span></div>'
+    +'<div class="pc-foot"><span>📅 '+esc(p.date)+'</span><span class="pc-view-cnt">👁 '+(p.views||0)+'</span><span class="pc-rt">⏱ '+rt+' 分鐘</span></div>'
     +'</div></div>';
 }
 
@@ -523,7 +539,10 @@ function openPost(id){
   const c=CAT_COLOR[p.category]||'#aaa';
   const badge=document.getElementById('a-badge');
   badge.textContent=p.category;badge.style.borderColor=c;badge.style.color=c;
+  p.views=(p.views||0)+1;
   setText('a-title',p.title);setText('a-date',p.date);setText('a-rt',readTime(p.body));setText('a-cat-tag','🏷 '+p.category);
+  setText('a-views',p.views);
+  sb.rpc('increment_post_views',{post_id:p.id}).catch(()=>{});
   const cover=document.getElementById('a-cover');
   if(p.image){cover.src=p.image;cover.style.display='block';}else{cover.style.display='none';}
   document.getElementById('a-body').innerHTML=p.body||'<p style="color:var(--dim)">（尚無內容）</p>';
@@ -580,6 +599,7 @@ function toggleMob(){document.getElementById('mob-menu').classList.toggle('open'
 
 /* ── UTILS ── */
 function esc(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+function fmtViews(n){n=+n||0;if(n>=10000)return Math.floor(n/1000)+'k+';if(n>=1000)return (n/1000).toFixed(1)+'k';return String(n);}
 
 /* ── INIT ── */
 initDB();

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -80,3 +80,68 @@ create policy "settings_admin_all"
 --    手動建立你的管理員帳號（Email + Password）
 --    不需要額外設定，登入後即為 authenticated role
 -- ============================================================
+
+-- ============================================================
+-- 6. 瀏覽數功能
+-- ============================================================
+
+-- 6.1 文章瀏覽數欄位
+alter table public.posts add column if not exists views bigint not null default 0;
+
+-- 6.2 網站總覽表（累積瀏覽 + 今日瀏覽）
+create table if not exists public.site_stats (
+  id         text primary key,
+  count      bigint not null default 0,
+  updated_at timestamptz not null default now()
+);
+
+-- 初始化 total 記錄
+insert into public.site_stats (id, count) values ('total', 0) on conflict (id) do nothing;
+
+-- 6.3 RLS
+alter table public.site_stats enable row level security;
+
+drop policy if exists "site_stats_public_read" on public.site_stats;
+create policy "site_stats_public_read"
+  on public.site_stats for select
+  to anon
+  using (true);
+
+drop policy if exists "site_stats_admin_all" on public.site_stats;
+create policy "site_stats_admin_all"
+  on public.site_stats for all
+  to authenticated
+  using (true) with check (true);
+
+-- 6.4 RPC：遞增文章瀏覽數（anon 可呼叫）
+create or replace function increment_post_views(post_id bigint)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  update public.posts set views = views + 1 where id = post_id and status = 'published';
+end;
+$$;
+
+grant execute on function increment_post_views(bigint) to anon;
+
+-- 6.5 RPC：遞增網站瀏覽數（anon 可呼叫）
+create or replace function increment_site_views()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  today_key text := current_date::text;
+begin
+  -- 累積總瀏覽
+  insert into public.site_stats (id, count) values ('total', 1)
+  on conflict (id) do update set count = site_stats.count + 1, updated_at = now();
+  -- 今日瀏覽
+  insert into public.site_stats (id, count) values (today_key, 1)
+  on conflict (id) do update set count = site_stats.count + 1, updated_at = now();
+end;
+$$;
+
+grant execute on function increment_site_views() to anon;


### PR DESCRIPTION
- posts 資料表新增 views 欄位，每次開啟文章自動遞增
- 新增 site_stats 資料表，追蹤累積瀏覽與今日瀏覽
- 新增 Supabase RPC 函式：increment_post_views、increment_site_views（anon 可呼叫）
- 文章卡片底部顯示 👁 瀏覽次數
- 文章頁 meta 區顯示瀏覽次數
- 關於我區塊新增「累積瀏覽」與「今日瀏覽」統計數字

https://claude.ai/code/session_018a3RbTkvkeLxmuaSAx6wCQ