### PR TITLE
feat: add Schema.org structured data, sitemap.xml, and robots.txt

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -394,6 +394,15 @@ textarea{resize:vertical;min-height:90px;line-height:1.7;}
   <div class="panel-title">資料管理</div>
   <div class="panel-sub">// DATA — 備份與還原所有資料</div>
   <div style="background:var(--bg2);border:1px solid var(--border);padding:20px;margin-bottom:16px;">
+    <div style="font-family:'Share Tech Mono',monospace;font-size:.7rem;color:var(--mid);margin-bottom:14px;">🗺 產生 Sitemap</div>
+    <p style="font-size:.85rem;color:var(--dim);margin-bottom:14px;">根據所有已發布文章產生完整的 sitemap.xml，下載後上傳至網站根目錄以取代靜態版本。</p>
+    <button class="btn btn-primary" id="sitemap-btn" onclick="generateSitemap()">⬇ 產生並下載 sitemap.xml</button>
+    <div id="sitemap-result" style="display:none;margin-top:14px;">
+      <div style="font-family:'Share Tech Mono',monospace;font-size:.65rem;color:var(--mid);margin-bottom:6px;">// 已產生內容（可複製確認）</div>
+      <textarea id="sitemap-output" readonly style="width:100%;height:140px;background:var(--bg3);border:1px solid var(--border);color:var(--dim);font-family:'Share Tech Mono',monospace;font-size:.65rem;padding:10px;resize:vertical;"></textarea>
+    </div>
+  </div>
+  <div style="background:var(--bg2);border:1px solid var(--border);padding:20px;margin-bottom:16px;">
     <div style="font-family:'Share Tech Mono',monospace;font-size:.7rem;color:var(--mid);margin-bottom:14px;">📤 匯出備份</div>
     <p style="font-size:.85rem;color:var(--dim);margin-bottom:14px;">將所有文章和設定下載為 JSON 備份檔案。</p>
     <button class="btn btn-primary" onclick="exportData()">⬇ 下載備份 JSON</button>
@@ -852,6 +861,33 @@ async function saveAbout(){
   const {error}=await sb.from('settings').upsert({key:'about',value:about});
   if(error){toast('儲存失敗：'+error.message,'error');return;}
   D.about=about;toast('關於我已儲存 ✓');
+}
+
+// ── SITEMAP ──
+async function generateSitemap(){
+  const btn=document.getElementById('sitemap-btn');
+  btn.textContent='產生中...';btn.disabled=true;
+  try{
+    const{data,error}=await sb.from('posts').select('slug,id,date').eq('status','published').order('date',{ascending:false});
+    if(error)throw error;
+    const base='https://operation.tw';
+    const now=new Date().toISOString().slice(0,10);
+    let xml='<?xml version="1.0" encoding="UTF-8"?>\n';
+    xml+='<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
+    xml+=`  <url>\n    <loc>${base}/</loc>\n    <lastmod>${now}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>1.0</priority>\n  </url>\n`;
+    xml+=`  <url>\n    <loc>${base}/podcast.html</loc>\n    <lastmod>${now}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n`;
+    for(const p of (data||[])){
+      const slug=encodeURIComponent(p.slug||p.id);
+      xml+=`  <url>\n    <loc>${base}/#/post/${slug}</loc>\n    <lastmod>${p.date||now}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.7</priority>\n  </url>\n`;
+    }
+    xml+='</urlset>';
+    document.getElementById('sitemap-output').value=xml;
+    document.getElementById('sitemap-result').style.display='block';
+    const blob=new Blob([xml],{type:'application/xml'});
+    const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='sitemap.xml';a.click();
+    toast('Sitemap 已產生並下載 ✓');
+  }catch(err){toast('產生失敗：'+err.message,'error');}
+  finally{btn.textContent='⬇ 產生並下載 sitemap.xml';btn.disabled=false;}
 }
 
 // ── DATA ──

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>操作一下 | operation.tw</title>
 <meta name="description" content="雲端、資安、AI、閱讀、成長 — 簡單的事情專注做">
+<link rel="canonical" href="https://operation.tw/">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"WebSite","name":"操作一下","alternateName":"operation.tw","url":"https://operation.tw","description":"雲端、資安、AI、閱讀、成長 — 簡單的事情專注做","inLanguage":"zh-TW","author":{"@type":"Person","name":"操作一下","url":"https://operation.tw"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://operation.tw/#/search/{search_term_string}"},"query-input":"required name=search_term_string"}}
+</script>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;700;900&family=Share+Tech+Mono&family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
 <style>
 :root{
@@ -574,12 +578,13 @@ function openPost(id){
   }else rs.style.display='none';
   showView('article');window.scrollTo(0,0);
   const slug=p.slug||p.id;
+  setPostMeta(p);
   if(location.hash!=='#/post/'+slug) history.pushState(null,'','#/post/'+slug);
 }
 
 /* ── VIEWS ── */
 function showView(name){document.querySelectorAll('.view').forEach(v=>v.classList.remove('active'));document.getElementById('v-'+name).classList.add('active');}
-function goHome(){showView('home');renderHome();if(location.hash)history.pushState(null,'','#/');}
+function goHome(){showView('home');renderHome();resetMeta();if(location.hash)history.pushState(null,'','#/');}
 
 /* ── ROUTE ── */
 function handleRoute(){
@@ -611,6 +616,38 @@ function share(platform){
 }
 function copyURL(btn){
   navigator.clipboard.writeText(location.href).then(()=>{btn.textContent='已複製 ✓';setTimeout(()=>btn.textContent='複製連結',2000);});
+}
+
+/* ── SEO / SCHEMA ── */
+function setPostMeta(p){
+  const slug=p.slug||p.id;
+  const url='https://operation.tw/#/post/'+encodeURIComponent(slug);
+  document.title=(p.title||'文章')+' | 操作一下';
+  const metaDesc=document.querySelector('meta[name="description"]');
+  if(metaDesc)metaDesc.content=p.excerpt||p.title||'';
+  const canonical=document.querySelector('link[rel="canonical"]');
+  if(canonical)canonical.href=url;
+  const schema={
+    '@context':'https://schema.org','@type':'BlogPosting',
+    'headline':p.title||'','description':p.excerpt||'',
+    'datePublished':p.date||'','dateModified':p.date||'',
+    'author':{'@type':'Person','name':'操作一下','url':'https://operation.tw'},
+    'publisher':{'@type':'Organization','name':'操作一下','url':'https://operation.tw'},
+    'url':url,'mainEntityOfPage':{'@type':'WebPage','@id':url},
+    'articleSection':p.category||'','keywords':p.category||''
+  };
+  if(p.image)schema.image=p.image;
+  let el=document.getElementById('ld-article');
+  if(!el){el=document.createElement('script');el.type='application/ld+json';el.id='ld-article';document.head.appendChild(el);}
+  el.textContent=JSON.stringify(schema);
+}
+function resetMeta(){
+  document.title='操作一下 | operation.tw';
+  const metaDesc=document.querySelector('meta[name="description"]');
+  if(metaDesc)metaDesc.content='雲端、資安、AI、閱讀、成長 — 簡單的事情專注做';
+  const canonical=document.querySelector('link[rel="canonical"]');
+  if(canonical)canonical.href='https://operation.tw/';
+  const el=document.getElementById('ld-article');if(el)el.remove();
 }
 
 /* ── NEWSLETTER ── */

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://operation.tw/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://operation.tw/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://operation.tw/podcast.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- index.html: inject WebSite JSON-LD schema in <head> for homepage rich snippet
- index.html: dynamically inject BlogPosting schema + update <title> and meta description per article when openPost() is called; restore on goHome()
- index.html: add canonical <link> tag, updated dynamically per article
- admin.html: add "Generate Sitemap" panel that fetches all published posts from Supabase and downloads a complete sitemap.xml
- sitemap.xml: static base sitemap with homepage and podcast
- robots.txt: allow all crawlers, reference sitemap URL

https://claude.ai/code/session_018a3RbTkvkeLxmuaSAx6wCQ