### PR TITLE
fix: add CNAME file for GitHub Pages custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+operation.tw


### PR DESCRIPTION
Add CNAME file to configure operation.tw as the custom domain for GitHub Pages hosting. This resolves the NotServedByPagesError by telling GitHub Pages which domain to serve the site on.

https://claude.ai/code/session_01KgvS2tsKHPf89NZbETNCgg