### PR TITLE
feat: migrate to GitHub Pages from Netlify

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare static files
+        run: |
+          mkdir -p _site
+          cp index.html admin.html podcast.html 404.html _site/
+          cp robots.txt sitemap.xml ghost-custom.css _site/
+          cp logo.jpg profile.jpg _site/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/404.html
+++ b/404.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>操作一下</title>
+  <script>
+    // GitHub Pages SPA redirect hack
+    // When GitHub Pages returns 404, redirect to /?/original/path
+    // so index.html can restore the URL and route correctly
+    var l = window.location;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      '/?/' + l.pathname.slice(1) + l.search + l.hash
+    );
+  </script>
+</head>
+<body></body>
+</html>

--- a/index.html
+++ b/index.html
@@ -457,6 +457,12 @@ footer{border-top:1px solid var(--border);padding:28px 24px;text-align:center;fo
 <footer id="footer-text">© 2025 操作一下 · 簡單的事情專注做</footer>
 
 <script>
+// ── GITHUB PAGES SPA ROUTING: restore URL from 404 redirect ──
+(function(){
+  var q=window.location.search;
+  if(q&&q[1]==='/'){history.replaceState(null,null,q.slice(1)||'/');}
+})();
+
 // ── SUPABASE ──
 const SUPABASE_URL='https://pvqvnmntqhsfzarbxayf.supabase.co';
 const SUPABASE_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB2cXZubW50cWhzZnphcmJ4YXlmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE2NjQ0MjUsImV4cCI6MjA4NzI0MDQyNX0.sKn8yzJos9F8ghKrp3icx6zR2RO39898DenWlLodpqA';


### PR DESCRIPTION
- Add 404.html: GitHub Pages SPA routing hack，將 /post/xxx 的直接 訪問重新導向至 /?/post/xxx，避免 404 錯誤
- Add index.html URL restoration: 頁面載入時還原真實路徑，讓 History API 路由繼續正常運作
- Add .github/workflows/deploy-pages.yml: push to main 自動部署靜態 檔案到 GitHub Pages，不再依賴 Netlify

https://claude.ai/code/session_018a3RbTkvkeLxmuaSAx6wCQ