### PR TITLE
fix: add default.png and google verification to deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,8 +29,9 @@ jobs:
         run: |
           mkdir -p _site
           cp index.html admin.html podcast.html 404.html _site/
+          cp googlee07640d17600c538.html _site/
           cp robots.txt sitemap.xml llms.txt ghost-custom.css _site/
-          cp logo.jpg profile.jpg _site/
+          cp logo.jpg profile.jpg default.png _site/
           cp CNAME _site/
 
       - name: Setup Pages


### PR DESCRIPTION
- default.png was referenced by og:image but never deployed (404 on live site)
- googlee07640d17600c538.html Google verification file also missing from deploy

https://claude.ai/code/session_01NiCCXX9VQQRT65H6FLsodt