### PR TITLE
fix: remove [skip ci] so sitemap/feed updates trigger deployment

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -51,6 +51,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to sitemap/feed"
           else
-            git commit -m "chore: update sitemap.xml and feed.xml [skip ci]"
+            git commit -m "chore: update sitemap.xml and feed.xml"
             git push
           fi


### PR DESCRIPTION
The [skip ci] tag in daily-news.yml prevented deploy-pages.yml from running after sitemap/feed updates, meaning dynamically generated sitemap.xml and feed.xml were committed but never deployed to GitHub Pages.

https://claude.ai/code/session_01NiCCXX9VQQRT65H6FLsodt