### PR TITLE
fix: add issues:write permission to daily-news workflow

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write           # 需要寫入權限以 commit sitemap/feed
+  issues: write             # 需要建立 issue 以通知 CI 失敗
 
 jobs:
   auto-post:


### PR DESCRIPTION
The Create issue on failure step requires issues=write scope. GITHUB_TOKEN was missing this permission causing 403.

https://claude.ai/code/session_01C1jjT7jNz4eFaCkrfk3KGJ