### PR TITLE
fix: bypass CDN cache for posts.json by appending timestamp query param

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,7 +610,7 @@ async function initDB(){
   // 2) /posts.json (GitHub Pages CDN) → 幾乎無冷啟動延遲
   if(!postsRendered){
     try{
-      const res=await fetch('/posts.json');
+      const res=await fetch('/posts.json?_='+Date.now());
       if(res.ok){
         const json=await res.json();
         if(json.posts&&json.posts.length){


### PR DESCRIPTION
Prevents browser and CDN from serving stale posts.json after daily workflow updates. Frontend was consistently showing articles from days ago because cached /posts.json was never revalidated.