### PR TITLE
fix: trigger deploy-pages when daily-news bot commit pushes to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Daily News Auto-Post"]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: read
@@ -16,6 +20,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
GitHub Actions does not fire push-triggered workflows when the push comes from github-actions[bot] (GITHUB_TOKEN). As a result, deploy-pages.yml was never re-running after the daily chore commits, so GitHub Pages stayed frozen at the last human PR merge.

Fix: add workflow_run trigger on 'Daily News Auto-Post' completion so deploy-pages runs automatically every day after the new post and updated posts.json are committed by the bot.