### PR TITLE
fix(ci): keep podcast feed updating and unblock Pages deploy

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -32,6 +32,10 @@ jobs:
         working-directory: scripts
 
       - name: Run auto-post script
+        # 部落格自動發文（依賴 Supabase / Anthropic）與 Podcast 更新互相獨立。
+        # 即使這步因 Supabase 暫時性錯誤（例如 500）失敗，也不該擋下後續的
+        # podcast/sitemap/feed 產生與 commit，否則 episodes.json 會停止更新。
+        continue-on-error: true
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,14 +35,21 @@ jobs:
       - name: Prepare static files
         run: |
           mkdir -p _site
-          cp index.html admin.html podcast.html 404.html _site/
-          cp googlee07640d17600c538.html _site/
-          cp robots.txt sitemap.xml feed.xml posts.json llms.txt ghost-custom.css _site/
-          if [ -f episodes.json ]; then cp episodes.json _site/; fi
-          cp logo.jpg profile.jpg default.png _site/
-          if [ -f logo.png ]; then cp logo.png _site/; fi
-          cp CNAME _site/
-          if [ -d images ]; then cp -r images _site/; fi
+          # 複製整個網站（含 post/、category/、about/ 等所有已產生的靜態頁面），
+          # 排除開發用檔案。避免漏抄任一目錄而讓部署後的頁面 404，
+          # 也不再因為硬編碼某個檔名（例如已不存在的 Google 驗證檔）而整步失敗。
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='scripts' \
+            --exclude='node_modules' \
+            --exclude='_site' \
+            --exclude='package.json' \
+            --exclude='package-lock.json' \
+            --exclude='zbpack.json' \
+            --exclude='supabase-setup.sql' \
+            --exclude='README.md' \
+            ./ _site/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## 為什麼 Podcast 串流在 6 月初之後停止更新

Podcast 頁面（`podcast.html`）是在前端 `fetch('/episodes.json')`，所以「集數有沒有更新」完全取決於兩條 CI pipeline。經查 GitHub Actions，**兩條都壞了**：

### 1. Daily News Auto-Post — 每天失敗，episodes.json 停在 5/31
CI log 顯示 `auto-post.js` 在「步驟 6：更新 posts.json」噴 `posts fetch failed: 500`（Supabase 暫時性 500 錯誤）。由於部落格自動發文與 Podcast 產生**共用同一個 job**，這個 crash 發生在「Generate podcast episodes JSON」與「Commit and push」之前 → `episodes.json` 永遠抓不到新集數。

**修法**：把 `Run auto-post script` 標記 `continue-on-error: true`。Podcast 產生與部落格發文本來就互相獨立，Supabase 出問題不該擋下 podcast/sitemap/feed 的產生與 commit；同時也讓 job 仍然 conclude `success`（deploy 工作流程需要它成功才會被觸發）。

### 2. Deploy to GitHub Pages — 30 次執行 0 成功
CI log：`cp: cannot stat 'googlee07640d17600c538.html': No such file or directory`。部署步驟硬編碼了一個**repo 裡根本不存在**的 Google 驗證檔（實際檔名是 `googlecf4b1d2478f1da9b.html`），`bash -e` 直接讓整步失敗，網站從來沒被發佈出去。

此外，原本的部署只手挑了少數檔案，**完全沒有複製 `post/`、`category/`、`about/`、`ai/`、`cloud/`、`docs/`、`podcast/`、`publiccloud/`、`security/`** 等目錄 — 一旦修好就會把整個部落格頁面從線上站台抹掉。

**修法**：改用 `rsync` 複製整個網站（排除 `.git/`、`.github/`、`scripts/` 等開發檔案）。一次解決「檔名不存在導致失敗」與「漏抄內容目錄」兩個問題，也讓未來新增目錄自動納入。

## 影響
- episodes.json 會在每日 Daily News 重新從 SoundOn RSS 抓取並 commit。
- Deploy 會成功，把含最新 `episodes.json` 與完整站台內容發佈到 GitHub Pages。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6DmHx31B1NdBtkNzK4oBz)_